### PR TITLE
Zip file store

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticStrings = "4db0a0c5-418a-4e1d-8806-cb305fe13294"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 AbstractTrees = "0.4"
@@ -31,4 +32,5 @@ StaticArrays = "1"
 StaticStrings = "0.2"
 StructArrays = "0.6"
 TranscodingStreams = "0.9"
+ZipFile = "0.10"
 julia = "1.8"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ If you just want to serialize arbitrary Julia data consider using https://github
 1. `ZGroup` can have JSON3 serializable attributes attached to any node or leaf.
 1. Data can be quickly accessed and modified in `ZGroup`.
 1. No file open close semantics. Use the Julia garbage collector to clean memory up.
-1. Save and load `ZGroup` in a directory in Zarr format.
-1. `ZGroup` saved to a directory can be read in other languages.
+1. Save and load `ZGroup` in a directory or zip file in Zarr v2 format.
+1. `ZGroup` saved to a directory or zip file can be read in other languages.
 
 
 ## Examples

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -2,11 +2,12 @@
 using EllipsisNotation
 
 function load_dir(dirpath::AbstractString)::ZGroup
-    if isdir(dirpath)
-        load_dir(DirectoryReader(dirpath))
+    reader = if isdir(dirpath)
+        DirectoryReader(dirpath)
     elseif isfile(dirpath)
-        error("zip file loading not implemented yet.")
+        BufferedZipReader(dirpath)
     end
+    load_dir(reader)
 end
 
 

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -3,11 +3,13 @@
 If dirpath ends in .zip, save to a zip file, otherwise save to a directory.
 """
 function save_dir(dirpath::AbstractString, z::ZGroup)
-    if endswith(dirpath, ".zip")
-        error("writing zip files not supported yet.")
+    writer = if endswith(dirpath, ".zip")
+        BufferedZipWriter(dirpath)
     else
-        save_dir(DirectoryWriter(dirpath), z)
+        DirectoryWriter(dirpath)
     end
+    save_dir(writer, z)
+    closewriter(writer)
 end
 
 

--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -1,7 +1,7 @@
 # a simple Artifacts.toml file
 [fixture]
-git-tree-sha1 = "088d30acb8d9dbef101906b6d3d7e72cc9332bfd"
+git-tree-sha1 = "6294e27997b8718402c19e59787fcacd88440a09"
 
     [[fixture.download]]
-    url = "https://github.com/medyan-dev/StorageTrees.jl/releases/download/v0.1.1/zarr-fixture.tar.gz"
-    sha256 = "fe5b4a68ae5b5e191ee63c713302df26cbafa12ee80ea089a8728daeb52574df"
+    url = "https://github.com/medyan-dev/StorageTrees.jl/releases/download/v0.2.0/zarr-fixture2.tar.gz"
+    sha256 = "a73086be29707a5a32209337fcb7c498e15f2bb9ac9d2ae243ce5846f61d8bec"

--- a/test/test_simple-usage.jl
+++ b/test/test_simple-usage.jl
@@ -163,6 +163,7 @@ end
     attrs(g["testgroup1/testarray1"])["foo"] = "bar3"
     mktempdir() do path
         # Note this will delete pre existing data at dirpath
+        # if path ends in ".zip" the data will be saved in a zip file instead.
         StorageTrees.save_dir(path,g)
         gload = StorageTrees.load_dir(path)
         @test collect(gload["testarray1"]) == data1
@@ -191,9 +192,19 @@ end
     g["testgroup1"]["testarray1"] = data3
     attrs(g["testgroup1/testarray1"])["foo"] = "bar3"
     mktempdir() do path
-        # Note this will delete pre existing data at path/test.zip
+        # Note this will delete pre existing data at "path/test.zip".
+        # If path ends in ".zip" the data will be saved in a zip file.
+        # This zip file can be read by zarr-python.
         StorageTrees.save_dir(joinpath(path,"test.zip"),g)
         @test isfile(joinpath(path,"test.zip"))
+        # load_dir can load zip files saved by save_dir, or saved by zarr-python.
+        # It can also load zip files created by zipping a zarr directory.
+        # Note the zip file must be in the format described in the zarr-python docs:
+        # "
+        #  Take note that the files in the Zip file must be relative to the root of the Zarr archive. 
+        #  You may find it easier to create such a Zip file with 7z, e.g.:
+        #       `7z a -tzip archive.zarr.zip archive.zarr/.`
+        # "
         gload = StorageTrees.load_dir(joinpath(path,"test.zip"))
         @test collect(gload["testarray1"]) == data1
         @test attrs(gload["testarray1"]) == OrderedDict([

--- a/test/test_simple-usage.jl
+++ b/test/test_simple-usage.jl
@@ -178,3 +178,33 @@ end
         ])
     end
 end
+
+@testset "saving and loading a zip file" begin
+    g = ZGroup()
+    data1 = rand(10,20)
+    g["testarray1"] = data1
+    attrs(g["testarray1"])["foo"] = "bar1"
+    data2 = rand(Int,20)
+    g["testarray2"] = data2
+    data3 = rand(UInt8,20)
+    g["testgroup1"] = ZGroup()
+    g["testgroup1"]["testarray1"] = data3
+    attrs(g["testgroup1/testarray1"])["foo"] = "bar3"
+    mktempdir() do path
+        # Note this will delete pre existing data at path/test.zip
+        StorageTrees.save_dir(joinpath(path,"test.zip"),g)
+        @test isfile(joinpath(path,"test.zip"))
+        gload = StorageTrees.load_dir(joinpath(path,"test.zip"))
+        @test collect(gload["testarray1"]) == data1
+        @test attrs(gload["testarray1"]) == OrderedDict([
+            "foo" => "bar1",
+        ])
+        @test collect(gload["testarray2"]) == data2
+        @test attrs(gload["testarray2"]) == OrderedDict([])
+        @test attrs(gload) == OrderedDict([])
+        @test collect(gload["testgroup1/testarray1"]) == data3
+        @test attrs(gload["testgroup1/testarray1"]) == OrderedDict([
+            "foo" => "bar3",
+        ])
+    end
+end


### PR DESCRIPTION
Add support for https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.ZipStore

Now when `save_dir` is called with a path that ends in ".zip" a zip file will be created instead of a directory.

Also, `load_dir` can load data from zip files created with `save_dir` or zarr-python.